### PR TITLE
make Ash Oredictionary compatible where possible

### DIFF
--- a/src/main/java/teamroots/embers/RegistryManager.java
+++ b/src/main/java/teamroots/embers/RegistryManager.java
@@ -491,6 +491,8 @@ public class RegistryManager {
 		GameRegistry.registerWorldGenerator(world_gen_small_ruin = new WorldGenSmallRuin(), weight ++);
 		
 		OreDictionary.registerOre("nuggetIron", nugget_iron);
+		OreDictionary.registerOre("dustAsh", dust_ash);
+		OreDictionary.registerOre("dustAshes", dust_ash);
 		
 		//GameRegistry.register(biomeCave = new BiomeCave());
 		

--- a/src/main/java/teamroots/embers/recipe/RecipeRegistry.java
+++ b/src/main/java/teamroots/embers/recipe/RecipeRegistry.java
@@ -320,7 +320,7 @@ public class RecipeRegistry {
 				"SAS",
 				" S ",
 				'S', "stone",
-				'A', RegistryManager.dust_ash}));
+				'A', "dustAsh"}));
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(RegistryManager.ashen_stone_slab,6),true,new Object[]{
 				"XXX",
 				'X', RegistryManager.ashen_stone}));
@@ -338,7 +338,7 @@ public class RecipeRegistry {
 				"SAS",
 				" S ",
 				'S', Blocks.STONEBRICK,
-				'A', RegistryManager.dust_ash}));
+				'A', "dustAsh"}));
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(RegistryManager.ashen_brick,4),true,new Object[]{
 				"SS",
 				"SS",


### PR DESCRIPTION
Ash is added by many other mods, sometimes as dustAsh and sometimes as dustAshes. This PR adds both oredictionary entries to ash, and makes the non-alchemy recipes use "dustAsh" instead of just the embers-specific ash. 